### PR TITLE
Yahoo fix wpt 81

### DIFF
--- a/src/main/java/org/jasig/portlet/weather/dao/yahoo/YahooWeatherDaoImpl.java
+++ b/src/main/java/org/jasig/portlet/weather/dao/yahoo/YahooWeatherDaoImpl.java
@@ -18,22 +18,7 @@
  */
 package org.jasig.portlet.weather.dao.yahoo;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.SocketException;
-import java.net.SocketTimeoutException;
-import java.util.Collection;
-import java.util.List;
-import java.util.Locale;
-
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpConnectionManager;
-import org.apache.commons.httpclient.HttpException;
-import org.apache.commons.httpclient.HttpMethod;
-import org.apache.commons.httpclient.HttpMethodRetryHandler;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
-import org.apache.commons.httpclient.NoHttpResponseException;
+import org.apache.commons.httpclient.*;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.params.HttpConnectionManagerParams;
 import org.apache.commons.httpclient.params.HttpMethodParams;
@@ -52,10 +37,18 @@ import org.springframework.context.MessageSourceResolvable;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.dao.DataRetrievalFailureException;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+
 public class YahooWeatherDaoImpl implements IWeatherDao, DisposableBean, InitializingBean {
 
-    private static final String FIND_URL = "http://where.yahooapis.com/v1/places.q(@QUERY@);count=10?appid=@KEY@";
-    private static final String WEATHER_URL = "http://weather.yahooapis.com/forecastrss?w=@LOCATION@&u=@UNIT@";
+    private static final String FIND_URL = "http://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20geo.places(10)%20where%20text%3D%22@QUERY@%22";
+    private static final String WEATHER_URL = "http://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20weather.forecast%20where%20woeid%3D@LOCATION@%20and%20u%3D%22@UNIT@%22";
     private static final String ERR_API_MISSING_KEY = "exception.missing.APIKey";
     private static final String ERR_GENERAL_KEY = "exception.generalError.title";
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -83,3 +83,7 @@ exception.missing.APIKey=The Weather service API key is not defined.
 
 invalid.location=Invalid location
 location.not.found=Location not found
+
+#units
+units.pressure.millibar=mb
+units.pressure.inches=in

--- a/src/main/resources/org/jasig/portlet/weather/dao/yahoo/YahooLocationParsingServiceImpl.groovy
+++ b/src/main/resources/org/jasig/portlet/weather/dao/yahoo/YahooLocationParsingServiceImpl.groovy
@@ -16,10 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import java.io.InputStream
-import groovy.xml.StreamingMarkupBuilder
-import org.jasig.portlet.weather.domain.*
+
 import org.jasig.portlet.weather.dao.yahoo.IYahooLocationParsingService
+import org.jasig.portlet.weather.domain.Location
 
 class YahooLocationParsingServiceImpl implements IYahooLocationParsingService {
 
@@ -27,7 +26,7 @@ class YahooLocationParsingServiceImpl implements IYahooLocationParsingService {
         def places = new XmlSlurper().parse(xml)
         
         def list = new ArrayList()
-        for (place in places.place) {
+        for (place in places.results.place) {
             def location = new Location()
             location.setLocationCode(place.woeid.toString())
             location.setCity(place.locality1.toString())

--- a/src/main/resources/org/jasig/portlet/weather/dao/yahoo/YahooWeatherParsingServiceImpl.groovy
+++ b/src/main/resources/org/jasig/portlet/weather/dao/yahoo/YahooWeatherParsingServiceImpl.groovy
@@ -17,13 +17,24 @@
  * under the License.
  */
 
+
+
+
+
+
+
 import org.jasig.portlet.weather.dao.yahoo.IYahooWeatherParsingService
 import org.jasig.portlet.weather.domain.Current
 import org.jasig.portlet.weather.domain.Forecast
 import org.jasig.portlet.weather.domain.Location
 import org.jasig.portlet.weather.domain.Weather
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationContext
 
 class YahooWeatherParsingServiceImpl implements IYahooWeatherParsingService {
+
+    @Autowired
+    ApplicationContext context
 
     Weather parseWeather(InputStream xml) {
         def rss = new XmlSlurper().parse(xml)
@@ -41,6 +52,11 @@ class YahooWeatherParsingServiceImpl implements IYahooWeatherParsingService {
         current.setWindDirection(rss.results.channel.wind.@direction.toString())
         current.setHumidity(rss.results.channel.atmosphere.@humidity.toDouble())
         current.setPressure(rss.results.channel.atmosphere.@pressure.toDouble())
+        if (current.getPressure() > 33) {
+            weather.setPressureUnit(context.getMessage("units.pressure.millibar", null, Locale.getDefault()))
+        } else {
+            weather.setPressureUnit(context.getMessage("units.pressure.inches", null, Locale.getDefault()))
+        }
         current.setImgUrl("https://s.yimg.com/zz/combo?/a/i/us/we/52/" + rss.results.channel.item.condition.@code.toString() + ".gif")
         weather.setCurrentWeather(current)
         

--- a/src/main/resources/org/jasig/portlet/weather/dao/yahoo/YahooWeatherParsingServiceImpl.groovy
+++ b/src/main/resources/org/jasig/portlet/weather/dao/yahoo/YahooWeatherParsingServiceImpl.groovy
@@ -16,10 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import java.io.InputStream
-import groovy.xml.StreamingMarkupBuilder
-import org.jasig.portlet.weather.domain.*
+
 import org.jasig.portlet.weather.dao.yahoo.IYahooWeatherParsingService
+import org.jasig.portlet.weather.domain.Current
+import org.jasig.portlet.weather.domain.Forecast
+import org.jasig.portlet.weather.domain.Location
+import org.jasig.portlet.weather.domain.Weather
 
 class YahooWeatherParsingServiceImpl implements IYahooWeatherParsingService {
 
@@ -27,35 +29,34 @@ class YahooWeatherParsingServiceImpl implements IYahooWeatherParsingService {
         def rss = new XmlSlurper().parse(xml)
         
         def weather = new Weather()
-        weather.setPressureUnit(rss.channel.units.@pressure.toString())
-        weather.setTemperatureUnit(rss.channel.units.@temperature.toString())
-        weather.setWindUnit(rss.channel.units.@speed.toString())
-        weather.setMoreInformationLink(rss.channel.link.toString())
+        weather.setPressureUnit(rss.results.channel.units.@pressure.toString())
+        weather.setTemperatureUnit(rss.results.channel.units.@temperature.toString())
+        weather.setWindUnit(rss.results.channel.units.@speed.toString())
+        weather.setMoreInformationLink(rss.results.channel.link.toString())
         
         def current = new Current()
-        current.setCondition(rss.channel.item.condition.@text.toString())
-        current.setTemperature(rss.channel.item.condition.@temp.toInteger())
-        current.setWindSpeed(rss.channel.wind.@speed.toDouble())
-        current.setWindDirection(rss.channel.wind.@direction.toString())
-        current.setHumidity(rss.channel.atmosphere.@humidity.toDouble())
-        current.setPressure(rss.channel.atmosphere.@pressure.toDouble())
-        current.setImgUrl("https://s.yimg.com/zz/combo?/a/i/us/we/52/" + rss.channel.item.condition.@code.toString() + ".gif")
+        current.setCondition(rss.results.channel.item.condition.@text.toString())
+        current.setTemperature(rss.results.channel.item.condition.@temp.toInteger())
+        current.setWindSpeed(rss.results.channel.wind.@speed.toDouble())
+        current.setWindDirection(rss.results.channel.wind.@direction.toString())
+        current.setHumidity(rss.results.channel.atmosphere.@humidity.toDouble())
+        current.setPressure(rss.results.channel.atmosphere.@pressure.toDouble())
+        current.setImgUrl("https://s.yimg.com/zz/combo?/a/i/us/we/52/" + rss.results.channel.item.condition.@code.toString() + ".gif")
         weather.setCurrentWeather(current)
         
         def location = new Location()
-        location.setCity(rss.channel.location.@city.toString())
-        if (!rss.channel.location.@region.toString().equals("")) {
-            location.setStateOrCountry(rss.channel.location.@region.toString())
+        location.setCity(rss.results.channel.location.@city.toString())
+        if (!rss.results.channel.location.@region.toString().equals("")) {
+            location.setStateOrCountry(rss.results.channel.location.@region.toString())
         } else {
-            location.setStateOrCountry(rss.channel.location.@country.toString())
+            location.setStateOrCountry(rss.results.channel.location.@country.toString())
         }
-        location.setLatitude(rss.channel.item.lat.toDouble())
-        location.setLongitude(rss.channel.item.long.toDouble())
-        location.setLongitude()
+        location.setLatitude(rss.results.channel.item.lat.toDouble())
+        location.setLongitude(rss.results.channel.item.long.toDouble())
         weather.setLocation(location)
         
         def list = new ArrayList()
-        for (f in rss.channel.item.forecast) {
+        for (f in rss.results.channel.item.forecast) {
             def forecast = new Forecast()
             forecast.setDay(f.@day.toString())
             forecast.setHighTemperature(f.@high.toInteger())

--- a/src/main/webapp/WEB-INF/context/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/context/applicationContext.xml
@@ -74,7 +74,7 @@
         script-source="classpath:org/jasig/portlet/weather/dao/yahoo/YahooLocationParsingServiceImpl.groovy"/>
 
 
-	<!-- messages.propreties Configuration -->
+	 <!--messages.properties Configuration -->
 	<bean id="messageSource" class="org.springframework.context.support.ResourceBundleMessageSource">
 		<property name="basenames">
 			<list>
@@ -82,7 +82,7 @@
 			</list>
 		</property>
 	</bean>
-
+    
     <bean id="ajaxPortletSupportService" class="org.jasig.web.service.AjaxPortletSupportService"/>
 
 	<!-- ========================= PORTLET SPECIFIC DEFINITIONS ========================= -->

--- a/src/test/java/org/jasig/portlet/weather/dao/yahoo/TestYahooWeatherDaoImpl.java
+++ b/src/test/java/org/jasig/portlet/weather/dao/yahoo/TestYahooWeatherDaoImpl.java
@@ -18,19 +18,18 @@
  */
 package org.jasig.portlet.weather.dao.yahoo;
 
-import java.io.InputStream;
-import java.util.List;
-
-import junit.framework.Assert;
-
 import org.jasig.portlet.weather.domain.Location;
 import org.jasig.portlet.weather.domain.Weather;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.io.InputStream;
+import java.util.List;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/testContext.xml")
@@ -49,15 +48,15 @@ public class TestYahooWeatherDaoImpl {
     
     @Test
     public void test() throws Exception {
-        InputStream is = applicationContext.getResource("classpath:/2502265.xml").getInputStream();
+        InputStream is = applicationContext.getResource("classpath:/2502265YQL.xml").getInputStream();
         Weather weather = weatherParsingService.parseWeather(is);
-        Assert.assertEquals(weather.getForecast().size(), 2);
-        Assert.assertEquals(weather.getCurrentWeather().getCondition(), "Fair");
+        Assert.assertEquals(weather.getForecast().size(), 10);
+        Assert.assertEquals(weather.getCurrentWeather().getCondition(), "Mostly Sunny");
     }
     
     @Test
     public void testSearch() throws Exception {
-        InputStream is = applicationContext.getResource("classpath:/yahooLondonSearch.xml").getInputStream();
+        InputStream is = applicationContext.getResource("classpath:/yahooLondonSearchYQL.xml").getInputStream();
         List<Location> locations = locationParsingService.parseLocations(is);
         Assert.assertEquals(locations.size(), 10);
     }

--- a/src/test/java/org/jasig/portlet/weather/dao/yahoo/TestYahooWeatherDaoImpl.java
+++ b/src/test/java/org/jasig/portlet/weather/dao/yahoo/TestYahooWeatherDaoImpl.java
@@ -30,6 +30,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.InputStream;
 import java.util.List;
+import java.util.Locale;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/testContext.xml")
@@ -45,13 +46,14 @@ public class TestYahooWeatherDaoImpl {
     
     @Autowired(required = true)
     private ApplicationContext applicationContext;
-    
+
     @Test
     public void test() throws Exception {
         InputStream is = applicationContext.getResource("classpath:/2502265YQL.xml").getInputStream();
         Weather weather = weatherParsingService.parseWeather(is);
         Assert.assertEquals(weather.getForecast().size(), 10);
         Assert.assertEquals(weather.getCurrentWeather().getCondition(), "Mostly Sunny");
+        Assert.assertEquals(weather.getPressureUnit(), "mb");
     }
     
     @Test
@@ -59,6 +61,11 @@ public class TestYahooWeatherDaoImpl {
         InputStream is = applicationContext.getResource("classpath:/yahooLondonSearchYQL.xml").getInputStream();
         List<Location> locations = locationParsingService.parseLocations(is);
         Assert.assertEquals(locations.size(), 10);
+    }
+
+    @Test
+    public void shouldReturnUnitsFromPropertiesFile() {
+        Assert.assertEquals(applicationContext.getMessage("units.pressure.inches", null, Locale.getDefault()), "in");
     }
 
 }

--- a/src/test/resources/2502265YQL.xml
+++ b/src/test/resources/2502265YQL.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<query xmlns:yahoo="http://www.yahooapis.com/v1/base.rng" yahoo:count="1" yahoo:created="2016-04-28T00:00:19Z" yahoo:lang="en-us">
+    <results>
+        <channel>
+            <yweather:units xmlns:yweather="http://xml.weather.yahoo.com/ns/rss/1.0" distance="mi" pressure="in" speed="mph" temperature="F" />
+            <title>Yahoo! Weather - Sunnyvale, CA, US</title>
+            <link>http://us.rd.yahoo.com/dailynews/rss/weather/Country__Country/*https://weather.yahoo.com/country/state/city-2502265/</link>
+            <description>Yahoo! Weather for Sunnyvale, CA, US</description>
+            <language>en-us</language>
+            <lastBuildDate>Wed, 27 Apr 2016 05:00 PM PDT</lastBuildDate>
+            <ttl>60</ttl>
+            <yweather:location xmlns:yweather="http://xml.weather.yahoo.com/ns/rss/1.0" city="Sunnyvale" country="United States" region=" CA" />
+            <yweather:wind xmlns:yweather="http://xml.weather.yahoo.com/ns/rss/1.0" chill="59" direction="295" speed="32" />
+            <yweather:atmosphere xmlns:yweather="http://xml.weather.yahoo.com/ns/rss/1.0" humidity="50" pressure="1004.0" rising="0" visibility="16.1" />
+            <yweather:astronomy xmlns:yweather="http://xml.weather.yahoo.com/ns/rss/1.0" sunrise="6:17 am" sunset="7:55 pm" />
+            <image>
+                <title>Yahoo! Weather</title>
+                <width>142</width>
+                <height>18</height>
+                <link>http://weather.yahoo.com</link>
+                <url>http://l.yimg.com/a/i/brand/purplelogo//uh/us/news-wea.gif</url>
+            </image>
+            <item>
+                <title>Conditions for Sunnyvale, CA, US at 04:00 PM PDT</title>
+                <geo:lat xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#">37.371609</geo:lat>
+                <geo:long xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#">-122.038254</geo:long>
+                <link>http://us.rd.yahoo.com/dailynews/rss/weather/Country__Country/*https://weather.yahoo.com/country/state/city-2502265/</link>
+                <pubDate>Wed, 27 Apr 2016 04:00 PM PDT</pubDate>
+                <yweather:condition xmlns:yweather="http://xml.weather.yahoo.com/ns/rss/1.0" code="34" date="Wed, 27 Apr 2016 04:00 PM PDT" temp="62" text="Mostly Sunny" />
+                <yweather:forecast xmlns:yweather="http://xml.weather.yahoo.com/ns/rss/1.0" code="47" date="27 Apr 2016" day="Wed" high="65" low="51" text="Scattered Thunderstorms" />
+                <yweather:forecast xmlns:yweather="http://xml.weather.yahoo.com/ns/rss/1.0" code="34" date="28 Apr 2016" day="Thu" high="71" low="51" text="Mostly Sunny" />
+                <yweather:forecast xmlns:yweather="http://xml.weather.yahoo.com/ns/rss/1.0" code="30" date="29 Apr 2016" day="Fri" high="77" low="51" text="Partly Cloudy" />
+                <yweather:forecast xmlns:yweather="http://xml.weather.yahoo.com/ns/rss/1.0" code="34" date="30 Apr 2016" day="Sat" high="79" low="52" text="Mostly Sunny" />
+                <yweather:forecast xmlns:yweather="http://xml.weather.yahoo.com/ns/rss/1.0" code="32" date="01 May 2016" day="Sun" high="88" low="59" text="Sunny" />
+                <yweather:forecast xmlns:yweather="http://xml.weather.yahoo.com/ns/rss/1.0" code="32" date="02 May 2016" day="Mon" high="85" low="58" text="Sunny" />
+                <yweather:forecast xmlns:yweather="http://xml.weather.yahoo.com/ns/rss/1.0" code="30" date="03 May 2016" day="Tue" high="80" low="56" text="Partly Cloudy" />
+                <yweather:forecast xmlns:yweather="http://xml.weather.yahoo.com/ns/rss/1.0" code="28" date="04 May 2016" day="Wed" high="77" low="55" text="Mostly Cloudy" />
+                <yweather:forecast xmlns:yweather="http://xml.weather.yahoo.com/ns/rss/1.0" code="28" date="05 May 2016" day="Thu" high="73" low="56" text="Mostly Cloudy" />
+                <yweather:forecast xmlns:yweather="http://xml.weather.yahoo.com/ns/rss/1.0" code="30" date="06 May 2016" day="Fri" high="71" low="56" text="Partly Cloudy" />
+                <description><![CDATA[<img src="http://l.yimg.com/a/i/us/we/52/23.gif"/> <BR /> <b>Current Conditions:</b> <BR />Breezy <BR /> <BR /> <b>Forecast:</b> <BR /> Wed - Scattered Thunderstorms. High: 65Low: 51 <BR /> Thu - Mostly Sunny. High: 71Low: 51 <BR /> Fri - Partly Cloudy. High: 77Low: 51 <BR /> Sat - Mostly Sunny. High: 79Low: 52 <BR /> Sun - Sunny. High: 88Low: 59 <BR /> <BR /> <a href="http://us.rd.yahoo.com/dailynews/rss/weather/Country__Country/*https://weather.yahoo.com/country/state/city-2502265/">Full Forecast at Yahoo! Weather</a> <BR /> <BR /> (provided by <a href="http://www.weather.com" >The Weather Channel</a>) <BR />]]></description>
+                <guid isPermaLink="false" />
+            </item>
+        </channel>
+    </results>
+</query>
+        <!--  total: 12  -->
+        <!--  main-887ea43f-0985-11e6-aa2e-f0921c192010  -->

--- a/src/test/resources/testContext.xml
+++ b/src/test/resources/testContext.xml
@@ -31,5 +31,14 @@
 
     <lang:groovy id="locationParsingService"
         script-source="classpath:org/jasig/portlet/weather/dao/yahoo/YahooLocationParsingServiceImpl.groovy"/>
-            
+
+    <!--messages.properties Configuration -->
+    <bean id="messageSource" class="org.springframework.context.support.ResourceBundleMessageSource">
+        <property name="basenames">
+            <list>
+                <value>messages</value>
+            </list>
+        </property>
+    </bean>
+
 </beans>

--- a/src/test/resources/yahooLondonSearchYQL.xml
+++ b/src/test/resources/yahooLondonSearchYQL.xml
@@ -1,0 +1,296 @@
+<query xmlns:yahoo="http://www.yahooapis.com/v1/base.rng" yahoo:count="10" yahoo:created="2016-04-27T23:49:22Z" yahoo:lang="en-US">
+    <results>
+        <place xmlns="http://where.yahooapis.com/v1/schema.rng" xmlns:yahoo="http://www.yahooapis.com/v1/base.rng" xml:lang="en-US" yahoo:uri="http://where.yahooapis.com/v1/place/44418">
+            <woeid>44418</woeid>
+            <placeTypeName code="7">Town</placeTypeName>
+            <name>London</name>
+            <country code="GB" type="Country" woeid="23424975">United Kingdom</country>
+            <admin1 code="" type="Country" woeid="24554868">England</admin1>
+            <admin2 code="" type="County" woeid="23416974">Greater London</admin2>
+            <admin3/>
+            <locality1 type="Town" woeid="44418">London</locality1>
+            <locality2/>
+            <postal/>
+            <centroid>
+                <latitude>51.507702</latitude>
+                <longitude>-0.12797</longitude>
+            </centroid>
+            <boundingBox>
+                <southWest>
+                    <latitude>51.286839</latitude>
+                    <longitude>-0.51035</longitude>
+                </southWest>
+                <northEast>
+                    <latitude>51.692322</latitude>
+                    <longitude>0.33403</longitude>
+                </northEast>
+            </boundingBox>
+            <areaRank>1</areaRank>
+            <popRank>1</popRank>
+            <timezone type="Time Zone" woeid="28350903">Europe/London</timezone>
+        </place>
+        <place xmlns="http://where.yahooapis.com/v1/schema.rng" xmlns:yahoo="http://www.yahooapis.com/v1/base.rng" xml:lang="en-US" yahoo:uri="http://where.yahooapis.com/v1/place/4063">
+            <woeid>4063</woeid>
+            <placeTypeName code="7">Town</placeTypeName>
+            <name>London</name>
+            <country code="CA" type="Country" woeid="23424775">Canada</country>
+            <admin1 code="CA-ON" type="Province" woeid="2344922">Ontario</admin1>
+            <admin2 code="" type="County/District" woeid="29375211">Middlesex</admin2>
+            <admin3/>
+            <locality1 type="Town" woeid="4063">London</locality1>
+            <locality2/>
+            <postal/>
+            <centroid>
+                <latitude>42.98325</latitude>
+                <longitude>-81.250031</longitude>
+            </centroid>
+            <boundingBox>
+                <southWest>
+                    <latitude>42.914261</latitude>
+                    <longitude>-81.371513</longitude>
+                </southWest>
+                <northEast>
+                    <latitude>43.060768</latitude>
+                    <longitude>-81.135658</longitude>
+                </northEast>
+            </boundingBox>
+            <areaRank>1</areaRank>
+            <popRank>1</popRank>
+            <timezone type="Time Zone" woeid="56043697">America/Toronto</timezone>
+        </place>
+        <place xmlns="http://where.yahooapis.com/v1/schema.rng" xmlns:yahoo="http://www.yahooapis.com/v1/base.rng" xml:lang="en-US" yahoo:uri="http://where.yahooapis.com/v1/place/2441293">
+            <woeid>2441293</woeid>
+            <placeTypeName code="7">Town</placeTypeName>
+            <name>London</name>
+            <country code="US" type="Country" woeid="23424977">United States</country>
+            <admin1 code="US-KY" type="State" woeid="2347576">Kentucky</admin1>
+            <admin2 code="" type="County" woeid="12588538">Laurel</admin2>
+            <admin3/>
+            <locality1 type="Town" woeid="2441293">London</locality1>
+            <locality2/>
+            <postal/>
+            <centroid>
+                <latitude>37.127369</latitude>
+                <longitude>-84.082008</longitude>
+            </centroid>
+            <boundingBox>
+                <southWest>
+                    <latitude>37.10281</latitude>
+                    <longitude>-84.126663</longitude>
+                </southWest>
+                <northEast>
+                    <latitude>37.15221</latitude>
+                    <longitude>-84.038658</longitude>
+                </northEast>
+            </boundingBox>
+            <areaRank>1</areaRank>
+            <popRank>1</popRank>
+            <timezone type="Time Zone" woeid="56043648">America/New_York</timezone>
+        </place>
+        <place xmlns="http://where.yahooapis.com/v1/schema.rng" xmlns:yahoo="http://www.yahooapis.com/v1/base.rng" xml:lang="en-US" yahoo:uri="http://where.yahooapis.com/v1/place/2441291">
+            <woeid>2441291</woeid>
+            <placeTypeName code="7">Town</placeTypeName>
+            <name>London</name>
+            <country code="US" type="Country" woeid="23424977">United States</country>
+            <admin1 code="US-TX" type="State" woeid="2347602">Texas</admin1>
+            <admin2 code="" type="County" woeid="12590140">Kimble</admin2>
+            <admin3/>
+            <locality1 type="Town" woeid="2441291">London</locality1>
+            <locality2/>
+            <postal type="Zip Code" woeid="12791265">76854</postal>
+            <centroid>
+                <latitude>30.68577</latitude>
+                <longitude>-99.56485</longitude>
+            </centroid>
+            <boundingBox>
+                <southWest>
+                    <latitude>30.67667</latitude>
+                    <longitude>-99.575417</longitude>
+                </southWest>
+                <northEast>
+                    <latitude>30.69486</latitude>
+                    <longitude>-99.554268</longitude>
+                </northEast>
+            </boundingBox>
+            <areaRank>1</areaRank>
+            <popRank>1</popRank>
+            <timezone type="Time Zone" woeid="56043661">America/Chicago</timezone>
+        </place>
+        <place xmlns="http://where.yahooapis.com/v1/schema.rng" xmlns:yahoo="http://www.yahooapis.com/v1/base.rng" xml:lang="en-US" yahoo:uri="http://where.yahooapis.com/v1/place/2441279">
+            <woeid>2441279</woeid>
+            <placeTypeName code="7">Town</placeTypeName>
+            <name>London</name>
+            <country code="US" type="Country" woeid="23424977">United States</country>
+            <admin1 code="US-CA" type="State" woeid="2347563">California</admin1>
+            <admin2 code="" type="County" woeid="12587723">Tulare</admin2>
+            <admin3/>
+            <locality1 type="Town" woeid="2441279">London</locality1>
+            <locality2/>
+            <postal type="Zip Code" woeid="12796963">93618</postal>
+            <centroid>
+                <latitude>36.480968</latitude>
+                <longitude>-119.444</longitude>
+            </centroid>
+            <boundingBox>
+                <southWest>
+                    <latitude>36.473438</latitude>
+                    <longitude>-119.449783</longitude>
+                </southWest>
+                <northEast>
+                    <latitude>36.48843</latitude>
+                    <longitude>-119.438492</longitude>
+                </northEast>
+            </boundingBox>
+            <areaRank>1</areaRank>
+            <popRank>1</popRank>
+            <timezone type="Time Zone" woeid="56043663">America/Los_Angeles</timezone>
+        </place>
+        <place xmlns="http://where.yahooapis.com/v1/schema.rng" xmlns:yahoo="http://www.yahooapis.com/v1/base.rng" xml:lang="en-US" yahoo:uri="http://where.yahooapis.com/v1/place/2441292">
+            <woeid>2441292</woeid>
+            <placeTypeName code="7">Town</placeTypeName>
+            <name>London</name>
+            <country code="US" type="Country" woeid="23424977">United States</country>
+            <admin1 code="US-OH" type="State" woeid="2347594">Ohio</admin1>
+            <admin2 code="" type="County" woeid="12589575">Madison</admin2>
+            <admin3/>
+            <locality1 type="Town" woeid="2441292">London</locality1>
+            <locality2/>
+            <postal type="Zip Code" woeid="12776172">43140</postal>
+            <centroid>
+                <latitude>39.88596</latitude>
+                <longitude>-83.448128</longitude>
+            </centroid>
+            <boundingBox>
+                <southWest>
+                    <latitude>39.859211</latitude>
+                    <longitude>-83.478882</longitude>
+                </southWest>
+                <northEast>
+                    <latitude>39.92178</latitude>
+                    <longitude>-83.393143</longitude>
+                </northEast>
+            </boundingBox>
+            <areaRank>1</areaRank>
+            <popRank>1</popRank>
+            <timezone type="Time Zone" woeid="56043648">America/New_York</timezone>
+        </place>
+        <place xmlns="http://where.yahooapis.com/v1/schema.rng" xmlns:yahoo="http://www.yahooapis.com/v1/base.rng" xml:lang="en-US" yahoo:uri="http://where.yahooapis.com/v1/place/2441289">
+            <woeid>2441289</woeid>
+            <placeTypeName code="33">Estate</placeTypeName>
+            <name>London</name>
+            <country code="US" type="Country" woeid="23424977">United States</country>
+            <admin1 code="US-WV" type="State" woeid="2347607">West Virginia</admin1>
+            <admin2 code="" type="County" woeid="12590498">Kanawha</admin2>
+            <admin3/>
+            <locality1/>
+            <locality2/>
+            <postal type="Zip Code" woeid="12768106">25039</postal>
+            <centroid>
+                <latitude>38.186329</latitude>
+                <longitude>-81.346451</longitude>
+            </centroid>
+            <boundingBox>
+                <southWest>
+                    <latitude>38.177231</latitude>
+                    <longitude>-81.358009</longitude>
+                </southWest>
+                <northEast>
+                    <latitude>38.195419</latitude>
+                    <longitude>-81.334877</longitude>
+                </northEast>
+            </boundingBox>
+            <areaRank>1</areaRank>
+            <popRank>1</popRank>
+            <timezone type="Time Zone" woeid="56043648">America/New_York</timezone>
+        </place>
+        <place xmlns="http://where.yahooapis.com/v1/schema.rng" xmlns:yahoo="http://www.yahooapis.com/v1/base.rng" xml:lang="en-US" yahoo:uri="http://where.yahooapis.com/v1/place/2441278">
+            <woeid>2441278</woeid>
+            <placeTypeName code="7">Town</placeTypeName>
+            <name>London</name>
+            <country code="US" type="Country" woeid="23424977">United States</country>
+            <admin1 code="US-AR" type="State" woeid="2347562">Arkansas</admin1>
+            <admin2 code="" type="County" woeid="12587652">Pope</admin2>
+            <admin3/>
+            <locality1 type="Town" woeid="2441278">London</locality1>
+            <locality2/>
+            <postal type="Zip Code" woeid="12789473">72847</postal>
+            <centroid>
+                <latitude>35.330799</latitude>
+                <longitude>-93.253899</longitude>
+            </centroid>
+            <boundingBox>
+                <southWest>
+                    <latitude>35.316891</latitude>
+                    <longitude>-93.265518</longitude>
+                </southWest>
+                <northEast>
+                    <latitude>35.338058</latitude>
+                    <longitude>-93.187363</longitude>
+                </northEast>
+            </boundingBox>
+            <areaRank>1</areaRank>
+            <popRank>1</popRank>
+            <timezone type="Time Zone" woeid="56043661">America/Chicago</timezone>
+        </place>
+        <place xmlns="http://where.yahooapis.com/v1/schema.rng" xmlns:yahoo="http://www.yahooapis.com/v1/base.rng" xml:lang="en-US" yahoo:uri="http://where.yahooapis.com/v1/place/2441286">
+            <woeid>2441286</woeid>
+            <placeTypeName code="33">Estate</placeTypeName>
+            <name>London</name>
+            <country code="US" type="Country" woeid="23424977">United States</country>
+            <admin1 code="US-OR" type="State" woeid="2347596">Oregon</admin1>
+            <admin2 code="" type="County" woeid="12589711">Lane</admin2>
+            <admin3/>
+            <locality1/>
+            <locality2/>
+            <postal type="Zip Code" woeid="12798656">97424</postal>
+            <centroid>
+                <latitude>43.635551</latitude>
+                <longitude>-123.091049</longitude>
+            </centroid>
+            <boundingBox>
+                <southWest>
+                    <latitude>43.62645</latitude>
+                    <longitude>-123.103607</longitude>
+                </southWest>
+                <northEast>
+                    <latitude>43.644642</latitude>
+                    <longitude>-123.078484</longitude>
+                </northEast>
+            </boundingBox>
+            <areaRank>1</areaRank>
+            <popRank>1</popRank>
+            <timezone type="Time Zone" woeid="56043663">America/Los_Angeles</timezone>
+        </place>
+        <place xmlns="http://where.yahooapis.com/v1/schema.rng" xmlns:yahoo="http://www.yahooapis.com/v1/base.rng" xml:lang="en-US" yahoo:uri="http://where.yahooapis.com/v1/place/2441281">
+            <woeid>2441281</woeid>
+            <placeTypeName code="33">Estate</placeTypeName>
+            <name>London</name>
+            <country code="US" type="Country" woeid="23424977">United States</country>
+            <admin1 code="US-MI" type="State" woeid="2347581">Michigan</admin1>
+            <admin2 code="" type="County" woeid="12588771">Monroe</admin2>
+            <admin3/>
+            <locality1/>
+            <locality2/>
+            <postal type="Zip Code" woeid="12778641">48159</postal>
+            <centroid>
+                <latitude>42.02021</latitude>
+                <longitude>-83.607811</longitude>
+            </centroid>
+            <boundingBox>
+                <southWest>
+                    <latitude>42.011108</latitude>
+                    <longitude>-83.620041</longitude>
+                </southWest>
+                <northEast>
+                    <latitude>42.029301</latitude>
+                    <longitude>-83.595573</longitude>
+                </northEast>
+            </boundingBox>
+            <areaRank>1</areaRank>
+            <popRank>1</popRank>
+            <timezone type="Time Zone" woeid="56043658">America/Detroit</timezone>
+        </place>
+    </results>
+</query>
+        <!--  total: 10  -->
+        <!--  main-0eadb987-01c5-11e6-bac7-d4ae52974741  -->


### PR DESCRIPTION
-Used new Yahoo Query Language (YQL) public endpoint for weather, which doesn't require OAuth1 but is limited to 2,000 requests per hour from an IP address.
-Used new YQL public endpoint for location search even though the old endpoint still worked; just keeping things synchronized with the "new" YQL way Yahoo does things.
-Added code to overwrite pressure units reported from Yahoo Weather (weather.com) which is wrong; anything over 33 (higher than highest pressure recorded on earth in inches of mercury) will be displayed as millibars (mb), 33 or less will be inches (in). Added these unit abbreviations to messages.properties.
-Added sample XML results for unit tests for weather and location.
-Added a couple test cases to verify units are correct and being pulled from messages.properties.